### PR TITLE
create_bridge mod to use custom bridges

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ paho-mqtt>=1.2
 pymongo
 pytest
 pyyaml
-git+https://github.com/RobotWebTools/rosbridge_suite.git#subdirectory=rosbridge_library
+git+https://github.com/RobotWebTools/rosbridge_suite.git@ros1#subdirectory=rosbridge_library
 rosgraph
 rosgraph-msgs
 roslib

--- a/src/mqtt_bridge/bridge.py
+++ b/src/mqtt_bridge/bridge.py
@@ -12,23 +12,13 @@ from uuid import uuid4
 
 from threading import Thread
 
-def create_bridge(factory: Union[str, "Bridge"], msg_type: Union[str, Type[rospy.Message]], topic_from: str,
-                  topic_to: str, frequency: Optional[float] = None, **kwargs) -> "Bridge":
+def create_bridge(factory: Union[str, "Bridge"], **kwargs) -> "Bridge":
     """ generate bridge instance using factory callable and arguments. if `factory` or `meg_type` is provided as string,
      this function will convert it to a corresponding object.
     """
     if isinstance(factory, str):
         factory = lookup_object(factory)
-    if not issubclass(factory, Bridge):
-        raise ValueError("factory should be Bridge subclass")
-    if isinstance(msg_type, str):
-        msg_type = lookup_object(msg_type)
-    if not issubclass(msg_type, rospy.Message):
-        raise TypeError(
-            "msg_type should be rospy.Message instance or its string"
-            "reprensentation")
-    return factory(
-        topic_from=topic_from, topic_to=topic_to, msg_type=msg_type, frequency=frequency, **kwargs)
+    return factory(**kwargs)
 
 
 class Bridge(object, metaclass=ABCMeta):


### PR DESCRIPTION
Issue #22
The custom dynamic bridges become unsuable as they do not contain all the required parameters expected by the default bridge. 
I have changed the create_bridge back to a similar state to what it was in the melodic branch for python 2.
Also added in the requirements a specific ros1 branch in the rosbridge suite.